### PR TITLE
feat: ModuleInstall 支持自定义

### DIFF
--- a/components/module-install/module-install.module.scss
+++ b/components/module-install/module-install.module.scss
@@ -42,9 +42,11 @@
     background-color: var(--rp-c-bg);
     border-radius: var(--rp-radius);
     margin: 0.5rem 0;
-    padding: 12px;
+    padding: 0.75rem;
+
     a {
       color: var(--rp-c-link);
+
       &:hover {
         opacity: 0.85;
       }
@@ -54,4 +56,11 @@
 
 .url-wrap {
   overflow-x: auto;
+}
+
+.item-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--rp-c-text-2);
 }


### PR DESCRIPTION
@VirgilClyne 保留原始写法，作为语法糖。新增自定义写法，内部 `children` 部分支持 markdown 语法渲染。eg:

```tsx
<ModuleInstall urlPrefix='https://github.com/NSRingo/WeatherKit/releases/latest/download/'>
  <ModuleInstall.Tab type='surge'>
    #### text
    <ModuleInstall.Item url='WeatherKit.sgmodule' title='iOS' badge='test'>
      foo bar
    </ModuleInstall.Item>
    <ModuleInstall.Item url='WeatherKit.macOS.sgmodule'>
      - 默认策略组名为🌑Proxy
      - 需要开启Surge的增强模式
    </ModuleInstall.Item>
  </ModuleInstall.Tab>
</ModuleInstall>
```